### PR TITLE
feat: add OpenAI support for terminal session cleaning

### DIFF
--- a/src/cli2ansible/adapters/outbound/llm/__init__.py
+++ b/src/cli2ansible/adapters/outbound/llm/__init__.py
@@ -1,1 +1,6 @@
 """LLM adapters for AI-powered analysis."""
+
+from cli2ansible.adapters.outbound.llm.anthropic_cleaner import AnthropicCleaner
+from cli2ansible.adapters.outbound.llm.openai_cleaner import OpenAICleaner
+
+__all__ = ["AnthropicCleaner", "OpenAICleaner"]

--- a/src/cli2ansible/adapters/outbound/llm/openai_cleaner.py
+++ b/src/cli2ansible/adapters/outbound/llm/openai_cleaner.py
@@ -1,0 +1,181 @@
+"""OpenAI-based terminal session cleaner."""
+
+import json
+from typing import Any
+from uuid import UUID
+
+import httpx
+from cli2ansible.domain.models import CleanedCommand, CleaningReport, Command
+from cli2ansible.domain.ports import LLMPort
+
+
+class OpenAICleaner(LLMPort):
+    """Use OpenAI GPT to clean terminal sessions."""
+
+    def __init__(self, api_key: str, model: str = "gpt-4o") -> None:
+        self.api_key = api_key
+        self.model = model
+        self.base_url = "https://api.openai.com/v1/chat/completions"
+
+    def clean_commands(
+        self, commands: list[Command], session_id: UUID
+    ) -> tuple[list[CleanedCommand], CleaningReport]:
+        """Analyze and clean terminal commands using OpenAI."""
+        if not commands:
+            return [], CleaningReport(
+                session_id=session_id,
+                original_command_count=0,
+                cleaned_command_count=0,
+                duplicates_removed=0,
+                error_corrections_removed=0,
+                cleaning_rationale="No commands to clean",
+            )
+
+        prompt = self._build_prompt(commands)
+        response = self._call_api(prompt)
+        return self._parse_response(response, commands, session_id)
+
+    def _build_prompt(self, commands: list[Command]) -> str:
+        """Build the prompt for OpenAI."""
+        cmd_list = "\n".join(
+            [
+                f"{i+1}. {cmd.raw} (timestamp: {cmd.timestamp})"
+                for i, cmd in enumerate(commands)
+            ]
+        )
+
+        return f"""Analyze the following terminal session commands and identify which ones are essential.
+
+Commands:
+{cmd_list}
+
+Your task:
+1. Identify duplicate commands (same command run multiple times)
+2. Identify error corrections (user made a typo and then fixed it)
+3. Keep only the essential commands needed to reproduce the desired outcome
+
+Return a JSON response with this structure:
+{{
+  "essential_commands": [
+    {{
+      "command": "the actual command",
+      "reason": "why this command is essential",
+      "is_duplicate": false,
+      "is_error_correction": false,
+      "first_occurrence_index": 0
+    }}
+  ],
+  "removed_commands": [
+    {{
+      "command": "the removed command",
+      "reason": "why it was removed (duplicate/error correction)",
+      "is_duplicate": true,
+      "is_error_correction": false,
+      "original_index": 5
+    }}
+  ],
+  "rationale": "overall explanation of cleaning decisions"
+}}
+
+Focus on:
+- Commands that accomplish the goal (keep)
+- Obvious typos followed by corrections (remove the typo)
+- Repeated identical commands (keep only first occurrence)
+- Failed commands followed by successful ones (remove failures)"""
+
+    def _call_api(self, prompt: str) -> dict[str, Any]:
+        """Call the OpenAI API."""
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        payload = {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a terminal session analyzer. Respond only with valid JSON.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+            "temperature": 0.3,
+            "response_format": {"type": "json_object"},
+        }
+
+        try:
+            with httpx.Client(timeout=60.0) as client:
+                response = client.post(self.base_url, headers=headers, json=payload)
+                response.raise_for_status()
+                result: dict[str, Any] = response.json()
+                return result
+        except httpx.HTTPStatusError as e:
+            # Don't expose response content in error
+            raise RuntimeError(
+                f"OpenAI API request failed with status {e.response.status_code}"
+            ) from e
+        except httpx.TimeoutException as e:
+            raise RuntimeError("OpenAI API request timed out") from e
+        except Exception as e:
+            raise RuntimeError("Failed to call OpenAI API") from e
+
+    def _parse_response(
+        self,
+        response: dict[str, Any],
+        original_commands: list[Command],
+        session_id: UUID,
+    ) -> tuple[list[CleanedCommand], CleaningReport]:
+        """Parse OpenAI's response into cleaned commands and report."""
+        choices = response.get("choices", [])
+        if not choices:
+            raise ValueError("Empty response from API")
+
+        message = choices[0].get("message", {})
+        content = message.get("content", "")
+
+        if not content:
+            raise ValueError("Empty content in API response")
+
+        data = json.loads(content)
+
+        cleaned_commands: list[CleanedCommand] = []
+        duplicates_removed = 0
+        error_corrections_removed = 0
+
+        # Process essential commands
+        for cmd_data in data.get("essential_commands", []):
+            idx = cmd_data.get("first_occurrence_index", 0)
+            original_cmd = (
+                original_commands[idx] if idx < len(original_commands) else None
+            )
+
+            if original_cmd:
+                cleaned_commands.append(
+                    CleanedCommand(
+                        session_id=session_id,
+                        command=cmd_data["command"],
+                        reason=cmd_data["reason"],
+                        first_occurrence=original_cmd.timestamp,
+                        occurrence_count=1,
+                        is_duplicate=cmd_data.get("is_duplicate", False),
+                        is_error_correction=cmd_data.get("is_error_correction", False),
+                    )
+                )
+
+        # Count removed items
+        for removed in data.get("removed_commands", []):
+            if removed.get("is_duplicate"):
+                duplicates_removed += 1
+            if removed.get("is_error_correction"):
+                error_corrections_removed += 1
+
+        report = CleaningReport(
+            session_id=session_id,
+            original_command_count=len(original_commands),
+            cleaned_command_count=len(cleaned_commands),
+            duplicates_removed=duplicates_removed,
+            error_corrections_removed=error_corrections_removed,
+            cleaning_rationale=data.get("rationale", ""),
+        )
+
+        return cleaned_commands, report

--- a/src/cli2ansible/app.py
+++ b/src/cli2ansible/app.py
@@ -4,15 +4,17 @@ from cli2ansible.adapters.inbound.http.api import create_app
 from cli2ansible.adapters.outbound.db.repository import SQLAlchemyRepository
 from cli2ansible.adapters.outbound.generators.ansible_role import AnsibleRoleGenerator
 from cli2ansible.adapters.outbound.llm.anthropic_cleaner import AnthropicCleaner
+from cli2ansible.adapters.outbound.llm.openai_cleaner import OpenAICleaner
 from cli2ansible.adapters.outbound.object_store.s3_store import S3ObjectStore
 from cli2ansible.adapters.outbound.translator.rules_engine import RulesEngine
+from cli2ansible.domain.ports import LLMPort
 from cli2ansible.domain.services import CleanSession, CompilePlaybook, IngestSession
 from cli2ansible.settings import settings
 
 # Global instances (for dependency injection)
 _repository: SQLAlchemyRepository | None = None
 _object_store: S3ObjectStore | None = None
-_llm_cleaner: AnthropicCleaner | None = None
+_llm_cleaner: LLMPort | None = None
 
 
 def get_repository() -> SQLAlchemyRepository:
@@ -37,13 +39,25 @@ def get_object_store() -> S3ObjectStore:
     return _object_store
 
 
-def get_llm_cleaner() -> AnthropicCleaner:
-    """Get or create LLM cleaner instance."""
+def get_llm_cleaner() -> LLMPort:
+    """Get or create LLM cleaner instance based on configured provider."""
     global _llm_cleaner
     if _llm_cleaner is None:
-        if not settings.anthropic_api_key:
-            raise ValueError("ANTHROPIC_API_KEY not configured")
-        _llm_cleaner = AnthropicCleaner(api_key=settings.anthropic_api_key)
+        provider = settings.llm_provider.lower()
+
+        if provider == "openai":
+            if not settings.openai_api_key:
+                raise ValueError("OPENAI_API_KEY not configured")
+            _llm_cleaner = OpenAICleaner(api_key=settings.openai_api_key)
+        elif provider == "anthropic":
+            if not settings.anthropic_api_key:
+                raise ValueError("ANTHROPIC_API_KEY not configured")
+            _llm_cleaner = AnthropicCleaner(api_key=settings.anthropic_api_key)
+        else:
+            raise ValueError(
+                f"Unknown LLM provider: {provider}. Must be 'anthropic' or 'openai'"
+            )
+
     return _llm_cleaner
 
 
@@ -57,9 +71,19 @@ def create_services() -> tuple[IngestSession, CompilePlaybook, CleanSession | No
     ingest_service = IngestSession(repo)
     compile_service = CompilePlaybook(repo, translator, generator, store)
 
-    # Only create clean service if API key is configured
+    # Only create clean service if LLM is configured
     clean_service: CleanSession | None = None
-    if settings.anthropic_api_key:
+    provider = settings.llm_provider.lower()
+
+    # Check if appropriate API key is configured
+    if provider == "anthropic":
+        has_api_key = bool(settings.anthropic_api_key)
+    elif provider == "openai":
+        has_api_key = bool(settings.openai_api_key)
+    else:
+        has_api_key = False
+
+    if has_api_key:
         llm = get_llm_cleaner()
         clean_service = CleanSession(repo, llm)
 

--- a/src/cli2ansible/settings.py
+++ b/src/cli2ansible/settings.py
@@ -1,5 +1,7 @@
 """Application settings using Pydantic."""
 
+from typing import Literal
+
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -26,6 +28,13 @@ class Settings(BaseSettings):
 
     # LLM (Anthropic Claude)
     anthropic_api_key: str = Field(default="")
+
+    # LLM (OpenAI)
+    openai_api_key: str = Field(default="")
+
+    # LLM Provider Selection
+    llm_provider: Literal["anthropic", "openai"] = Field(default="anthropic")
+
     max_commands_for_cleaning: int = Field(default=500)
 
 

--- a/tests/unit/test_openai_cleaner.py
+++ b/tests/unit/test_openai_cleaner.py
@@ -1,0 +1,396 @@
+"""Unit tests for OpenAICleaner adapter."""
+
+import json
+from unittest.mock import Mock, patch
+from uuid import uuid4
+
+import pytest
+from cli2ansible.adapters.outbound.llm.openai_cleaner import OpenAICleaner
+from cli2ansible.domain.models import Command
+
+
+@pytest.fixture()
+def cleaner() -> OpenAICleaner:
+    """Create OpenAICleaner instance."""
+    return OpenAICleaner(api_key="test-key-123", model="gpt-4o")
+
+
+@pytest.fixture()
+def sample_commands() -> list[Command]:
+    """Create sample commands for testing."""
+    session_id = uuid4()
+    return [
+        Command(
+            session_id=session_id,
+            raw="apt-get install nginx",
+            normalized="apt-get install nginx",
+            timestamp=1.0,
+        ),
+        Command(
+            session_id=session_id,
+            raw="apt-get install nginx",
+            normalized="apt-get install nginx",
+            timestamp=2.0,
+        ),
+        Command(
+            session_id=session_id,
+            raw="systemctl start nginx",
+            normalized="systemctl start nginx",
+            timestamp=3.0,
+        ),
+    ]
+
+
+def test_clean_commands_empty_list(cleaner: OpenAICleaner) -> None:
+    """Test cleaning with empty command list."""
+    session_id = uuid4()
+
+    # Act
+    cleaned_commands, report = cleaner.clean_commands([], session_id)
+
+    # Assert
+    assert len(cleaned_commands) == 0
+    assert report.session_id == session_id
+    assert report.original_command_count == 0
+    assert report.cleaned_command_count == 0
+    assert report.duplicates_removed == 0
+    assert report.error_corrections_removed == 0
+    assert "No commands" in report.cleaning_rationale
+
+
+@patch("cli2ansible.adapters.outbound.llm.openai_cleaner.httpx.Client")
+def test_clean_commands_calls_api_correctly(
+    mock_client_class: Mock, cleaner: OpenAICleaner, sample_commands: list[Command]
+) -> None:
+    """Test that clean_commands makes correct API call."""
+    session_id = sample_commands[0].session_id
+
+    # Arrange: Mock HTTP client
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "choices": [
+            {
+                "message": {
+                    "content": json.dumps(
+                        {
+                            "essential_commands": [
+                                {
+                                    "command": "apt-get install nginx",
+                                    "reason": "Install web server",
+                                    "is_duplicate": False,
+                                    "is_error_correction": False,
+                                    "first_occurrence_index": 0,
+                                },
+                                {
+                                    "command": "systemctl start nginx",
+                                    "reason": "Start service",
+                                    "is_duplicate": False,
+                                    "is_error_correction": False,
+                                    "first_occurrence_index": 2,
+                                },
+                            ],
+                            "removed_commands": [
+                                {
+                                    "command": "apt-get install nginx",
+                                    "reason": "Duplicate of command 1",
+                                    "is_duplicate": True,
+                                    "is_error_correction": False,
+                                    "original_index": 1,
+                                }
+                            ],
+                            "rationale": "Removed 1 duplicate command",
+                        }
+                    )
+                }
+            }
+        ]
+    }
+    mock_client = Mock()
+    mock_client.post.return_value = mock_response
+    mock_client.__enter__ = Mock(return_value=mock_client)
+    mock_client.__exit__ = Mock(return_value=False)
+    mock_client_class.return_value = mock_client
+
+    # Act
+    cleaned_commands, report = cleaner.clean_commands(sample_commands, session_id)
+
+    # Assert: Verify API call
+    mock_client.post.assert_called_once()
+    call_args = mock_client.post.call_args
+    assert call_args[0][0] == "https://api.openai.com/v1/chat/completions"
+
+    # Verify headers
+    headers = call_args[1]["headers"]
+    assert headers["Authorization"] == "Bearer test-key-123"
+    assert headers["Content-Type"] == "application/json"
+
+    # Verify payload
+    payload = call_args[1]["json"]
+    assert payload["model"] == "gpt-4o"
+    assert payload["temperature"] == 0.3
+    assert payload["response_format"] == {"type": "json_object"}
+    assert len(payload["messages"]) == 2
+    assert payload["messages"][0]["role"] == "system"
+    assert (
+        payload["messages"][0]["content"]
+        == "You are a terminal session analyzer. Respond only with valid JSON."
+    )
+    assert payload["messages"][1]["role"] == "user"
+    assert "apt-get install nginx" in payload["messages"][1]["content"]
+
+    # Verify results
+    assert len(cleaned_commands) == 2
+    assert cleaned_commands[0].command == "apt-get install nginx"
+    assert cleaned_commands[1].command == "systemctl start nginx"
+    assert report.duplicates_removed == 1
+    assert report.original_command_count == 3
+    assert report.cleaned_command_count == 2
+
+
+@patch("cli2ansible.adapters.outbound.llm.openai_cleaner.httpx.Client")
+def test_parse_response_correctly(
+    mock_client_class: Mock, cleaner: OpenAICleaner, sample_commands: list[Command]
+) -> None:
+    """Test that API response is parsed correctly into domain models."""
+    session_id = sample_commands[0].session_id
+
+    # Arrange
+    api_response = {
+        "choices": [
+            {
+                "message": {
+                    "content": json.dumps(
+                        {
+                            "essential_commands": [
+                                {
+                                    "command": "apt-get install nginx",
+                                    "reason": "Package installation",
+                                    "is_duplicate": False,
+                                    "is_error_correction": False,
+                                    "first_occurrence_index": 0,
+                                }
+                            ],
+                            "removed_commands": [
+                                {
+                                    "command": "apt-get install nginx",
+                                    "reason": "Duplicate",
+                                    "is_duplicate": True,
+                                    "is_error_correction": False,
+                                    "original_index": 1,
+                                },
+                                {
+                                    "command": "systemctl start nginx",
+                                    "reason": "Error correction",
+                                    "is_duplicate": False,
+                                    "is_error_correction": True,
+                                    "original_index": 2,
+                                },
+                            ],
+                            "rationale": "Removed 1 duplicate and 1 error correction",
+                        }
+                    )
+                }
+            }
+        ]
+    }
+
+    mock_response = Mock()
+    mock_response.json.return_value = api_response
+    mock_client = Mock()
+    mock_client.post.return_value = mock_response
+    mock_client.__enter__ = Mock(return_value=mock_client)
+    mock_client.__exit__ = Mock(return_value=False)
+    mock_client_class.return_value = mock_client
+
+    # Act
+    cleaned_commands, report = cleaner.clean_commands(sample_commands, session_id)
+
+    # Assert: Verify parsed CleanedCommand objects
+    assert len(cleaned_commands) == 1
+    assert cleaned_commands[0].session_id == session_id
+    assert cleaned_commands[0].command == "apt-get install nginx"
+    assert cleaned_commands[0].reason == "Package installation"
+    assert cleaned_commands[0].first_occurrence == 1.0  # From sample_commands[0]
+    assert cleaned_commands[0].is_duplicate is False
+    assert cleaned_commands[0].is_error_correction is False
+
+    # Verify parsed CleaningReport
+    assert report.session_id == session_id
+    assert report.original_command_count == 3
+    assert report.cleaned_command_count == 1
+    assert report.duplicates_removed == 1
+    assert report.error_corrections_removed == 1
+    assert report.cleaning_rationale == "Removed 1 duplicate and 1 error correction"
+
+
+def test_build_prompt_includes_all_commands(cleaner: OpenAICleaner) -> None:
+    """Test that prompt includes all commands with metadata."""
+    session_id = uuid4()
+    commands = [
+        Command(
+            session_id=session_id,
+            raw="echo hello",
+            normalized="echo hello",
+            timestamp=1.5,
+        ),
+        Command(
+            session_id=session_id,
+            raw="echo world",
+            normalized="echo world",
+            timestamp=2.5,
+        ),
+    ]
+
+    # Act
+    prompt = cleaner._build_prompt(commands)
+
+    # Assert
+    assert "1. echo hello (timestamp: 1.5)" in prompt
+    assert "2. echo world (timestamp: 2.5)" in prompt
+    assert "duplicate" in prompt.lower()
+    assert "error correction" in prompt.lower()
+    assert "JSON" in prompt
+
+
+@patch("cli2ansible.adapters.outbound.llm.openai_cleaner.httpx.Client")
+def test_api_http_status_error(
+    mock_client_class: Mock, cleaner: OpenAICleaner, sample_commands: list[Command]
+) -> None:
+    """Test handling of HTTP status errors from OpenAI API."""
+    session_id = sample_commands[0].session_id
+
+    # Arrange: Mock 401 unauthorized error
+    import httpx
+
+    mock_response = Mock()
+    mock_response.status_code = 401
+    mock_client = Mock()
+    mock_client.post.side_effect = httpx.HTTPStatusError(
+        "Unauthorized", request=Mock(), response=mock_response
+    )
+    mock_client.__enter__ = Mock(return_value=mock_client)
+    mock_client.__exit__ = Mock(return_value=False)
+    mock_client_class.return_value = mock_client
+
+    # Act & Assert
+    with pytest.raises(RuntimeError, match="OpenAI API request failed with status 401"):
+        cleaner.clean_commands(sample_commands, session_id)
+
+
+@patch("cli2ansible.adapters.outbound.llm.openai_cleaner.httpx.Client")
+def test_api_timeout_error(
+    mock_client_class: Mock, cleaner: OpenAICleaner, sample_commands: list[Command]
+) -> None:
+    """Test handling of timeout errors from OpenAI API."""
+    session_id = sample_commands[0].session_id
+
+    # Arrange: Mock timeout
+    import httpx
+
+    mock_client = Mock()
+    mock_client.post.side_effect = httpx.TimeoutException("Request timed out")
+    mock_client.__enter__ = Mock(return_value=mock_client)
+    mock_client.__exit__ = Mock(return_value=False)
+    mock_client_class.return_value = mock_client
+
+    # Act & Assert
+    with pytest.raises(RuntimeError, match="OpenAI API request timed out"):
+        cleaner.clean_commands(sample_commands, session_id)
+
+
+@patch("cli2ansible.adapters.outbound.llm.openai_cleaner.httpx.Client")
+def test_api_general_exception(
+    mock_client_class: Mock, cleaner: OpenAICleaner, sample_commands: list[Command]
+) -> None:
+    """Test handling of general exceptions from OpenAI API."""
+    session_id = sample_commands[0].session_id
+
+    # Arrange: Mock generic exception
+    mock_client = Mock()
+    mock_client.post.side_effect = Exception("Something went wrong")
+    mock_client.__enter__ = Mock(return_value=mock_client)
+    mock_client.__exit__ = Mock(return_value=False)
+    mock_client_class.return_value = mock_client
+
+    # Act & Assert
+    with pytest.raises(RuntimeError, match="Failed to call OpenAI API"):
+        cleaner.clean_commands(sample_commands, session_id)
+
+
+@patch("cli2ansible.adapters.outbound.llm.openai_cleaner.httpx.Client")
+def test_parse_response_empty_choices(
+    mock_client_class: Mock, cleaner: OpenAICleaner, sample_commands: list[Command]
+) -> None:
+    """Test handling of empty choices in API response."""
+    session_id = sample_commands[0].session_id
+
+    # Arrange: Mock response with empty choices
+    mock_response = Mock()
+    mock_response.json.return_value = {"choices": []}
+    mock_client = Mock()
+    mock_client.post.return_value = mock_response
+    mock_client.__enter__ = Mock(return_value=mock_client)
+    mock_client.__exit__ = Mock(return_value=False)
+    mock_client_class.return_value = mock_client
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="Empty response from API"):
+        cleaner.clean_commands(sample_commands, session_id)
+
+
+@patch("cli2ansible.adapters.outbound.llm.openai_cleaner.httpx.Client")
+def test_parse_response_empty_content(
+    mock_client_class: Mock, cleaner: OpenAICleaner, sample_commands: list[Command]
+) -> None:
+    """Test handling of empty content in API response."""
+    session_id = sample_commands[0].session_id
+
+    # Arrange: Mock response with empty content
+    mock_response = Mock()
+    mock_response.json.return_value = {"choices": [{"message": {"content": ""}}]}
+    mock_client = Mock()
+    mock_client.post.return_value = mock_response
+    mock_client.__enter__ = Mock(return_value=mock_client)
+    mock_client.__exit__ = Mock(return_value=False)
+    mock_client_class.return_value = mock_client
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="Empty content in API response"):
+        cleaner.clean_commands(sample_commands, session_id)
+
+
+@patch("cli2ansible.adapters.outbound.llm.openai_cleaner.httpx.Client")
+def test_client_timeout_configuration(
+    mock_client_class: Mock, cleaner: OpenAICleaner, sample_commands: list[Command]
+) -> None:
+    """Test that HTTP client is configured with correct timeout."""
+    session_id = sample_commands[0].session_id
+
+    # Arrange: Mock successful response
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "choices": [
+            {
+                "message": {
+                    "content": json.dumps(
+                        {
+                            "essential_commands": [],
+                            "removed_commands": [],
+                            "rationale": "Test",
+                        }
+                    )
+                }
+            }
+        ]
+    }
+    mock_client = Mock()
+    mock_client.post.return_value = mock_response
+    mock_client.__enter__ = Mock(return_value=mock_client)
+    mock_client.__exit__ = Mock(return_value=False)
+    mock_client_class.return_value = mock_client
+
+    # Act
+    cleaner.clean_commands(sample_commands, session_id)
+
+    # Assert: Verify client created with timeout
+    mock_client_class.assert_called_once_with(timeout=60.0)


### PR DESCRIPTION
Add OpenAI as an alternative LLM provider alongside Anthropic for cleaning terminal sessions. Users can now choose between providers via the LLM_PROVIDER environment variable.

Changes:
- Implement OpenAICleaner adapter using OpenAI API
- Add provider selection logic to app.py
- Add configuration settings for OpenAI API key
- Use Literal type for provider validation
- Add comprehensive unit tests for OpenAICleaner
- Security: Address medium-severity findings from security review

🤖 Generated with [Claude Code](https://claude.com/claude-code)