### PR TITLE
Fix Pydantic Validation Error in Cast Upload and Event Endpoints

### DIFF
--- a/src/cli2ansible/api/v1/cast.py
+++ b/src/cli2ansible/api/v1/cast.py
@@ -5,6 +5,7 @@ from typing import Any
 from uuid import UUID
 
 from cli2ansible.api.schemas import CastUploadResponse
+from cli2ansible.api.v1.utils import event_dto_to_response
 from cli2ansible.application.errors import BadRequestError
 from fastapi import APIRouter, UploadFile
 
@@ -51,9 +52,12 @@ def create_router(ingest_service: Any, compile_service: Any) -> APIRouter:
         # Use service to upload cast file and auto-compile
         # Service handles: upload → parse → store → auto-compile (with graceful failure)
         # The service will validate file size and raise TooLarge if needed
-        events = ingest_service.upload_cast_file_and_auto_compile(
+        event_dtos = ingest_service.upload_cast_file_and_auto_compile(
             session_id, file.filename, file_data, compile_service
         )
+
+        # Convert DTOs to Pydantic models at the API layer boundary
+        events = [event_dto_to_response(dto) for dto in event_dtos]
 
         return CastUploadResponse(
             status="parsed",

--- a/src/cli2ansible/api/v1/events.py
+++ b/src/cli2ansible/api/v1/events.py
@@ -13,6 +13,7 @@ from cli2ansible.api.schemas import (
     EventUpdateRequest,
     EventUpdateResult,
 )
+from cli2ansible.api.v1.utils import event_dto_to_response
 from cli2ansible.application.errors import ApplicationError
 from fastapi import APIRouter
 
@@ -72,7 +73,10 @@ def create_router(ingest_service: Any) -> APIRouter:
             ApplicationError: 404 if session not found
         """
         # Service validates session exists and retrieves events
-        events = ingest_service.get_events(session_id)
+        event_dtos = ingest_service.get_events(session_id)
+
+        # Convert DTOs to Pydantic models at the API layer boundary
+        events = [event_dto_to_response(dto) for dto in event_dtos]
 
         return EventsListResponse(
             session_id=session_id,
@@ -115,7 +119,10 @@ def create_router(ingest_service: Any) -> APIRouter:
                 )
 
                 # Service validates and updates event with optimistic locking
-                updated_event = ingest_service.update_event(session_id, update.id, update_dto)
+                updated_event_dto = ingest_service.update_event(session_id, update.id, update_dto)
+
+                # Convert DTO to Pydantic model at the API layer boundary
+                updated_event = event_dto_to_response(updated_event_dto)
 
                 formatted_results.append(
                     EventUpdateResult(
@@ -164,6 +171,9 @@ def create_router(ingest_service: Any) -> APIRouter:
         )
 
         # Service validates session, event, and applies update with optimistic locking
-        return ingest_service.update_event(session_id, event_id, update_dto)
+        updated_event_dto = ingest_service.update_event(session_id, event_id, update_dto)
+
+        # Convert DTO to Pydantic model at the API layer boundary
+        return event_dto_to_response(updated_event_dto)
 
     return router

--- a/src/cli2ansible/api/v1/utils.py
+++ b/src/cli2ansible/api/v1/utils.py
@@ -4,8 +4,10 @@ from typing import Any
 
 from cli2ansible.api.schemas import (
     CastFileResponse,
+    EventResponse,
     SessionResponse,
 )
+from cli2ansible.application.dtos import EventResponseDTO
 from cli2ansible.domain.entities import CastFile
 
 
@@ -28,4 +30,28 @@ def session_to_response(session: Any, cast_file: CastFile | None = None) -> Sess
         updated_at=session.updated_at,
         metadata=session.metadata,
         cast_file=cast_file_response,
+    )
+
+
+def event_dto_to_response(dto: EventResponseDTO) -> EventResponse:
+    """Convert EventResponseDTO to EventResponse Pydantic model.
+
+    This function handles the conversion from application layer DTOs (dataclasses)
+    to API layer Pydantic schemas at the layer boundary, maintaining proper
+    separation of concerns in the hexagonal architecture.
+
+    Args:
+        dto: EventResponseDTO dataclass from application layer
+
+    Returns:
+        EventResponse Pydantic model for API layer
+    """
+    return EventResponse(
+        id=dto.id,
+        session_id=dto.session_id,
+        timestamp=dto.timestamp,
+        event_type=dto.event_type,
+        data=dto.data,
+        sequence=dto.sequence,
+        version=dto.version,
     )


### PR DESCRIPTION
## Summary

Fixes #29 - Resolves Pydantic validation error that was causing 500 Internal Server Error when uploading `.cast` files and retrieving events.

## Problem

The API endpoints were passing application layer DTOs (dataclasses) directly to Pydantic response models, causing validation errors because Pydantic cannot automatically convert dataclasses to Pydantic models.

**Error:**
```
pydantic_core._pydantic_core.ValidationError: 4 validation errors for CastUploadResponse
events.0
  Input should be a valid dictionary or instance of EventResponse [type=model_type, input_value=EventResponseDTO(...)]
```

## Solution

Implemented proper DTO-to-Pydantic conversion at the API layer boundary to maintain hexagonal architecture principles.

## Changes Made

### 1. Created Conversion Utility (`src/cli2ansible/api/v1/utils.py`)
- Added `event_dto_to_response()` helper function
- Converts `EventResponseDTO` (dataclass) to `EventResponse` (Pydantic model)
- Reusable across all API endpoints

### 2. Fixed Cast Upload Endpoint (`src/cli2ansible/api/v1/cast.py`)
- `POST /sessions/{session_id}/cast`
- Converts `EventResponseDTO` list to `EventResponse` list before constructing response
- Prevents Pydantic validation error when uploading `.cast` files

### 3. Fixed Event Endpoints (`src/cli2ansible/api/v1/events.py`)
- `GET /sessions/{session_id}/events` - Converts DTOs to Pydantic models
- `PATCH /sessions/{session_id}/events/batch` - Converts DTOs in batch updates
- `PATCH /sessions/{session_id}/events/{event_id}` - Converts DTOs in single updates

## Architecture Compliance

This fix maintains **hexagonal architecture** principles by:
- ✅ Keeping application layer DTOs (dataclasses) separate from API layer schemas (Pydantic models)
- ✅ Converting at the API layer boundary (adapter layer)
- ✅ Not leaking implementation details across layers
- ✅ Proper separation of concerns

## Testing

- ✅ All 101 tests passing
- ✅ No regressions introduced
- ✅ Proper layer boundary conversion implemented

## Impact

### Before
- ❌ Cast file upload returns 500 Internal Server Error
- ❌ Event endpoints fail with Pydantic validation errors
- ❌ Users cannot upload `.cast` files

### After
- ✅ Cast file upload returns 200 OK with proper response
- ✅ Event endpoints work correctly
- ✅ Users can successfully upload and manage `.cast` files

## Related Issues

Closes #29

## Checklist

- [x] Code follows project style guidelines
- [x] All tests passing (101/101)
- [x] No regressions introduced
- [x] Maintains hexagonal architecture principles
- [x] Proper layer separation implemented
- [x] Issue #29 documented and closed

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author